### PR TITLE
Resolve merge conflict in issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,6 @@
 blank_issues_enabled: false
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
+
 contact_links:
   - name: 💬 Discussions
     url: https://github.com/digdilem/taskpony/discussions
     about: Ask questions or discuss ideas
->>>>>>> 3d6f2eb (Add github forms)
-=======
->>>>>>> 55aab08 (Add github forms-b)
-=======
->>>>>>> github/main


### PR DESCRIPTION
This PR removes unresolved merge conflict markers from the GitHub issue template
configuration file and leaves the intended `contact_links` setup intact.